### PR TITLE
Made it work with NodeJS 6.9.1 on arm7l (Orange Pi)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+
+OLED JS Pi over i2c-bus
+========================
+
+## What is this directory?
+
+This directory contains a working example of NodeJS, a (typically) ARM board (Orange Pi Zero), and a 128x64 I2C SSD1306 display.
+
+## Install
+
+```
+npm install
+cp ../oled.js node_modules/oled-i2c-bus/
+node clock.js
+```

--- a/examples/clock.js
+++ b/examples/clock.js
@@ -1,8 +1,16 @@
+/*
+ * clock.js
+ * Display a digital clock on a small I2C connected display
+ * 
+ * 2016-11-28 v1.0 Harald Kubota
+ */
+
+
 "use strict";
 
 var i2c = require('i2c-bus'),
-  i2cBus = i2c.openSync(0),
-  oled = require('oled-i2c-bus');
+    i2cBus = i2c.openSync(0),
+    oled = require('oled-i2c-bus');
 
 const SIZE_X=128,
       SIZE_Y=64;
@@ -25,6 +33,7 @@ oled.drawPixel([
     [0, SIZE_Y-1, 1],
     [0, 0, 1]
 ]);
+
 oled.drawLine(1, 1, SIZE_X-2, 1, 1);
 oled.drawLine(SIZE_X-2, 1, SIZE_X-2, SIZE_Y-2, 1);
 oled.drawLine(SIZE_X-2, SIZE_Y-2, 1, SIZE_Y-2, 1);
@@ -51,7 +60,7 @@ function displayClock() {
 
   // Location fits 128x64 OLED
   oled.setCursor(12, 25);
-  oled.writeString(font, 2, hour+":"+min+":"+sec, 1), true;
+  oled.writeString(font, 2, hour+":"+min+":"+sec, 1, true);
 }
 
 setInterval(displayClock, 1000);

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,0 +1,58 @@
+"use strict";
+
+var i2c = require('i2c-bus'),
+  i2cBus = i2c.openSync(0),
+  oled = require('oled-i2c-bus');
+
+const SIZE_X=128,
+      SIZE_Y=64;
+
+var opts = {
+  width: SIZE_X,
+  height: SIZE_Y,
+  address: 0x3C
+};
+
+var oled = new oled(i2cBus, opts);
+
+
+oled.clearDisplay();
+oled.turnOnDisplay();
+
+oled.drawPixel([
+    [SIZE_X-1, 0, 1],
+    [SIZE_X-1, SIZE_Y-1, 1],
+    [0, SIZE_Y-1, 1],
+    [0, 0, 1]
+]);
+oled.drawLine(1, 1, SIZE_X-2, 1, 1);
+oled.drawLine(SIZE_X-2, 1, SIZE_X-2, SIZE_Y-2, 1);
+oled.drawLine(SIZE_X-2, SIZE_Y-2, 1, SIZE_Y-2, 1);
+oled.drawLine(1, SIZE_Y-2, 1, 1, 1);
+
+var font = require('oled-font-5x7');
+
+// Clock
+
+function displayClock() {
+  var date=new Date();
+  var hour = date.getHours();
+  hour = (hour < 10 ? "0" : "") + hour;
+  var min  = date.getMinutes();
+  min = (min < 10 ? "0" : "") + min;
+  var sec  = date.getSeconds();
+  sec = (sec < 10 ? "0" : "") + sec;
+
+  var year = date.getFullYear();
+  var month = date.getMonth() + 1;
+  month = (month < 10 ? "0" : "") + month;
+  var day  = date.getDate();
+  day = (day < 10 ? "0" : "") + day;
+
+  // Location fits 128x64 OLED
+  oled.setCursor(12, 25);
+  oled.writeString(font, 2, hour+":"+min+":"+sec, 1), true;
+}
+
+setInterval(displayClock, 1000);
+

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "test-oled",
+  "version": "1.0.0",
+  "description": "Testing OLED SSD1306 display with nodeJS",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/haraldkubota/oled-i2c-bus"
+  },
+  "keywords": [
+    "oled",
+    "i2c"
+  ],
+  "author": "Harald Kubota",
+  "license": "MIT",
+  "dependencies": {
+    "i2c-bus": "^1.1.2",
+    "oled-font-5x7": "^1.0.0",
+    "oled-i2c-bus": "^1.0.8"
+  }
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "test-oled",
+  "name": "examples",
   "version": "1.0.0",
   "description": "Testing OLED SSD1306 display with nodeJS",
-  "main": "index.js",
+  "main": "clock.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Hi,

Took me some time to figure out why this was not working. Might be a too new NodeJS version (version 6 deprecated new Buffer(array) as an example, but mostly setTimeout(tick(callback),0) is notworking at all).

Tested on Orange Pi Zero on a 128x64 OLED via I²C. Works well now.
Thanks for creating this. I could not make oled-js-pi work (similar errors, probably related to NodeJS v6 too).

Harald
