### PR TITLE
Speed up page update on display and page clear

### DIFF
--- a/oled.js
+++ b/oled.js
@@ -330,9 +330,8 @@ Oled.prototype.update = function() {
     }
 
     // write buffer data
-    for (v = 0; v < bufferLen; v += 1) {
-      this._transfer('data', this.buffer[v]);
-    }
+		var bufferToSend = Buffer.concat([Buffer.from([0x40]), this.buffer]);
+		var sentCount = this.wire.i2cWriteSync(this.ADDRESS, bufferToSend.length, bufferToSend);
 
   }.bind(this));
 }
@@ -365,18 +364,11 @@ Oled.prototype.turnOnDisplay = function() {
 Oled.prototype.clearDisplay = function(sync) {
   var immed = (typeof sync === 'undefined') ? true : sync;
   // write off pixels
-  //this.buffer.fill(0x00);
-  for (var i = 0; i < this.buffer.length; i += 1) {
-    if (this.buffer[i] !== 0x00) {
-      this.buffer[i] = 0x00;
-      if (this.dirtyBytes.indexOf(i) === -1) {
-        this.dirtyBytes.push(i);
-      }
-    }
-  }
-  if (immed) {
-    this._updateDirtyBytes(this.dirtyBytes);
-  }
+  this.buffer.fill(0x00);
+	if (immed) {
+		this.update();
+	}
+
 }
 
 // invert pixels on oled


### PR DESCRIPTION
I am using oled-i2c-bus to display an interactive menu on a SSD1306 0.96 128x64 OLED display attached to a Raspberry Pi Zero.
The library works very well except for a few design flaws that can be easily corrected.
The most important one is the display speed. By using _transfer function, the payload is segmented into individual bytes that are send each in a separate transaction. These transactions add the data byte (0x40) before the payload byte thus doubling the throughput.
This has the unpleasant effect of one actually seeing the screen as it slowly refreshes.
However, the payload bytes can also be sent in a burst, with a single leading data byte 0x40, bypassing _transfer function altogether and writing directly to i2c. Therefore the update time is halved.
This doesn't sound as much in theory but in practice is a huge improvement as the eye sees an almost instant update as opposed to a slooooow refresh.
Another improvement would be the actual clearDisplay function which is very complicated and slow. A clear display action should simply fill the buffer with 0x00 and if required, update the display.