### PR TITLE
Enhancement to add support for larger fonts.

### DIFF
--- a/oled.js
+++ b/oled.js
@@ -209,7 +209,7 @@ Oled.prototype.writeString = function(font, size, string, color, wrap, sync) {
         compare = (font.width * size * slen) + (size * (len -1));
 
     // wrap words if necessary
-    if (wrap && len > 1 && (offset >= (this.WIDTH - compare)) ) {
+    if (wrap && len > 1 && w > 0 && (offset >= (this.WIDTH - compare)) ) {
       offset = 0;
 
       this.cursor_y += (font.height * size) + this.LINESPACING;
@@ -227,9 +227,9 @@ Oled.prototype.writeString = function(font, size, string, color, wrap, sync) {
         // look up the position of the char, pull out the buffer slice
         var charBuf = this._findCharBuf(font, stringArr[i]);
         // read the bits in the bytes that make up the char
-        var charBytes = this._readCharBytes(charBuf);
+        var charBytes = this._readCharBytes(charBuf, font.height);
         // draw the entire character
-        this._drawChar(charBytes, size, false);
+        this._drawChar(charBytes, font.height, size, false);
 
         // calc new x position for the next char, add a touch of padding too if it's a non space char
         //padding = (stringArr[i] === ' ') ? 0 : this.LETTERSPACING;
@@ -251,14 +251,14 @@ Oled.prototype.writeString = function(font, size, string, color, wrap, sync) {
 }
 
 // draw an individual character to the screen
-Oled.prototype._drawChar = function(byteArray, size, sync) {
+Oled.prototype._drawChar = function(byteArray, charHeight, size, sync) {
   // take your positions...
   var x = this.cursor_x,
       y = this.cursor_y;
 
   // loop through the byte array containing the hexes for the char
   for (var i = 0; i < byteArray.length; i += 1) {
-    for (var j = 0; j < 8; j += 1) {
+    for (var j = 0; j < charHeight; j += 1) {
       // pull color out
       var color = byteArray[i][j],
           xpos, ypos;
@@ -278,7 +278,7 @@ Oled.prototype._drawChar = function(byteArray, size, sync) {
 }
 
 // get character bytes from the supplied font object in order to send to framebuffer
-Oled.prototype._readCharBytes = function(byteArray) {
+Oled.prototype._readCharBytes = function(byteArray, charHeight) {
   var bitArr = [],
       bitCharArr = [];
   // loop through each byte supplied for a char
@@ -286,7 +286,7 @@ Oled.prototype._readCharBytes = function(byteArray) {
     // set current byte
     var byte = byteArray[i];
     // read each byte
-    for (var j = 0; j < 8; j += 1) {
+    for (var j = 0; j < charHeight; j += 1) {
       // shift bits right until all are read
       var bit = byte >> j & 1;
       bitArr.push(bit);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oled-i2c-bus",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "NodeJS module for controlling oled devices on the Raspbery Pi (including the SSD1306 OLED screens)",
   "main": "oled.js",
   "devDependencies": {


### PR DESCRIPTION
This change is backward compatible with the 1.0.11 version.

I recently have constructed additional oled fonts from a site I found that had character sizes > 8 pixels.  These fonts are useful for displays that are larger than 128x32 such as 128x64 or 128x128.  I plan to add these fonts in the very near future to npm but before I do, I need a module that will support them.

The current oled font character structure is such that each element in the array is a represents a column and bit values of the byte represent rows in the column.  The current code supports font with character widths larger than 8 pixels but it does not support fonts with character heights larger than 8 pixels.

This update includes a minor fix to word wrap (should no wrap the first word) and the changes to support fonts with character height larger than 8 pixels.
Version number bumped to 1.0.12.

I am hoping that you can publish a new version to NPM.

Regards,
LynnieMagoo